### PR TITLE
Fix wrong character attribution in multiplayer runs.

### DIFF
--- a/backend/src/main/kotlin/studythespire/api/runs/ImportRunFileFeature.kt
+++ b/backend/src/main/kotlin/studythespire/api/runs/ImportRunFileFeature.kt
@@ -1,6 +1,7 @@
 package studythespire.api.runs
 
 import io.ktor.server.application.Application
+import io.ktor.server.request.receiveText
 import io.ktor.server.routing.routing
 import kairo.feature.Feature
 import kairo.rest.HasRouting
@@ -20,14 +21,16 @@ internal class ImportRunFileFeature(
         auth { auth.authenticate(call) }
         handle {
           val token = call.attributes[UploadTokenAuth.UploadTokenKey]
-          val rawJson = endpoint.body
+          val rawJson = call.receiveText()
           val sha = sha256Hex(rawJson)
           val fileName = call.request.headers["X-Run-File-Name"]
+          val localPlayerId = call.request.headers["X-Local-Player-Id"]
           val result = runs.importRun(
             userId = token.userId,
             sha256 = sha,
             fileName = fileName,
             rawJson = rawJson,
+            localPlayerId = localPlayerId,
           )
           when (result) {
             is ImportResult.Inserted -> ImportRunFileRep(imported = true, runId = result.runId.toString())

--- a/backend/src/main/kotlin/studythespire/api/runs/RunStore.kt
+++ b/backend/src/main/kotlin/studythespire/api/runs/RunStore.kt
@@ -46,6 +46,7 @@ internal class RunStore(
     sha256: String,
     fileName: String?,
     rawJson: String,
+    localPlayerId: String? = null,
   ): ImportResult = suspendTransaction(db = database) {
     val existing = RunImportsTable
       .select(RunImportsTable.id)
@@ -61,7 +62,7 @@ internal class RunStore(
       return@suspendTransaction ImportResult.Duplicate(RunId(runRow[RunsTable.id]))
     }
 
-    val parsed = parseRunFile(rawJson)
+    val parsed = parseRunFile(rawJson, localPlayerId)
     val now = Clock.System.now()
     val newImportId = Uuid.random()
     val newRunId = Uuid.random()
@@ -226,13 +227,23 @@ internal class RunStore(
       )
     }
 
-  private fun parseRunFile(rawJson: String): ParsedRun {
+  private fun parseRunFile(rawJson: String, localPlayerId: String?): ParsedRun {
     val obj = json.parseToJsonElement(rawJson).jsonObject
     val wasAbandoned = obj.requireBool("was_abandoned")
     val win = obj.requireBool("win")
     val players = obj["players"] as? JsonArray
-    val firstPlayer = players?.firstOrNull() as? JsonObject
-    val characterClass = firstPlayer?.optString("character")
+    // Co-op runs include every lobby player in `players[]`, so we match on the
+    // uploader's Steam ID when the mod sends one. Falling back to index 0 keeps
+    // single-player and pre-header uploads working.
+    val localPlayer = players?.let { p ->
+      localPlayerId?.let { id ->
+        p.firstOrNull { el ->
+          val pid = (el as? JsonObject)?.get("id") as? kotlinx.serialization.json.JsonPrimitive
+          pid?.content == id
+        } as? JsonObject
+      } ?: (p.firstOrNull() as? JsonObject)
+    }
+    val characterClass = localPlayer?.optString("character")
 
     return ParsedRun(
       status = RunStatus.derive(wasAbandoned = wasAbandoned, win = win),

--- a/backend/src/main/kotlin/studythespire/api/runs/RunsApi.kt
+++ b/backend/src/main/kotlin/studythespire/api/runs/RunsApi.kt
@@ -77,10 +77,12 @@ internal object StatsApi {
 }
 
 internal object ImportsApi {
+  // Body is intentionally not declared here — the handler reads it via
+  // `call.receiveText()` to bypass Kairo/Jackson, which round-trips JSON
+  // numbers through a representation that drops precision on 17-digit
+  // SteamID64s in `players[].id` (e.g. ...908 → ...910).
   @Rest("POST", "/imports/run-file")
   @Rest.ContentType("application/json")
   @Rest.Accept("application/json")
-  data class Post(
-    override val body: String,
-  ) : RestEndpoint<String, ImportRunFileRep>()
+  data object Post : RestEndpoint<Unit, ImportRunFileRep>()
 }

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `POST /imports/run-file` now documents `X-Local-Player-Id` header. The mod sends the uploader's SteamID64 so the importer can pick the right player out of co-op `players[]` arrays; absent header falls back to `players[0]` (single-player and pre-fix uploads).
 - `GET /stats/summary` returning aggregate stats (totals, win rate, per-character + per-ascension breakdowns, top death causes) for the authenticated user.
 - `Stats` tag for stats endpoints.
 - `StatsSummaryResponse`, `CharacterStat`, `AscensionStat`, `DeathCauseStat` schemas.

--- a/contracts/api/openapi.yaml
+++ b/contracts/api/openapi.yaml
@@ -327,6 +327,11 @@ paths:
         `contracts/runfile/run.v9.schema.json` before upload when possible. Optional
         `X-Run-File-Name` header preserves the source file name (e.g. `1776658411.run`).
 
+        Optional `X-Local-Player-Id` header carries the uploader's SteamID64 (parsed
+        by the mod from the file path: `steam/<steamId>/profile<n>/saves/history/`).
+        Co-op runs include every lobby player in `players[]`; the importer uses this
+        header to pick the matching entry, falling back to `players[0]` when absent.
+
         Idempotent on `(user, sha256(body))`: re-uploading the same file returns
         `imported: false` with the existing `runId`.
       security:
@@ -337,6 +342,12 @@ paths:
           required: false
           schema:
             type: string
+        - in: header
+          name: X-Local-Player-Id
+          required: false
+          schema:
+            type: string
+            example: "76561198153651735"
       requestBody:
         required: true
         content:

--- a/mod/StudyTheSpire/Http/StudyTheSpireClient.cs
+++ b/mod/StudyTheSpire/Http/StudyTheSpireClient.cs
@@ -70,6 +70,7 @@ internal sealed class StudyTheSpireClient
         string rawJson,
         string fileName,
         string sha256,
+        string localPlayerId,
         CancellationToken ct = default)
     {
         if (_disabled) return null;
@@ -80,6 +81,7 @@ internal sealed class StudyTheSpireClient
                 var content = new StringContent(rawJson, System.Text.Encoding.UTF8, "application/json");
                 var req = new HttpRequestMessage(HttpMethod.Post, "imports/run-file") { Content = content };
                 req.Headers.TryAddWithoutValidation("X-Run-File-Name", fileName);
+                req.Headers.TryAddWithoutValidation("X-Local-Player-Id", localPlayerId);
                 return _http.SendAsync(req, ct);
             },
             classify: r => ClassifyImport(r, fileName),

--- a/mod/StudyTheSpire/Saves/RunFileUploader.cs
+++ b/mod/StudyTheSpire/Saves/RunFileUploader.cs
@@ -26,7 +26,7 @@ internal sealed class RunFileUploader
         _log = log;
     }
 
-    public async Task UploadAsync(FileInfo file, CancellationToken ct = default)
+    public async Task UploadAsync(FileInfo file, string localPlayerId, CancellationToken ct = default)
     {
         string text;
         try
@@ -53,7 +53,7 @@ internal sealed class RunFileUploader
             return;
         }
 
-        var result = await _client.UploadRunFileAsync(text, file.Name, sha, ct).ConfigureAwait(false);
+        var result = await _client.UploadRunFileAsync(text, file.Name, sha, localPlayerId, ct).ConfigureAwait(false);
         if (result is null)
         {
             // Client logged the failure (401/4xx/exhausted retries). Leave cache alone — retry next session.

--- a/mod/StudyTheSpire/Saves/SaveFinder.cs
+++ b/mod/StudyTheSpire/Saves/SaveFinder.cs
@@ -14,46 +14,52 @@ namespace StudyTheSpire.Saves;
 ///   Windows: %APPDATA%/SlayTheSpire2/steam/&lt;steamId&gt;/profile&lt;n&gt;/saves/history/
 ///   Linux:   ~/.local/share/SlayTheSpire2/steam/&lt;steamId&gt;/profile&lt;n&gt;/saves/history/
 /// A user can have multiple profiles; we return every profile that contains a
-/// saves/history dir so the watcher can monitor all of them.
+/// saves/history dir so the watcher can monitor all of them. The Steam ID parsed
+/// from the path is returned alongside each dir — the importer needs it to pick
+/// the local player out of co-op runs whose `players[]` arrays contain everyone
+/// in the lobby.
 /// </summary>
 internal static class SaveFinder
 {
-    public static IReadOnlyList<string> FindHistoryDirs(ModLogger log)
+    internal readonly record struct HistoryDir(string Path, string SteamId);
+
+    public static IReadOnlyList<HistoryDir> FindHistoryDirs(ModLogger log)
     {
         var root = ResolveAppDataRoot();
         if (root is null || !Directory.Exists(root))
         {
             log.Warn($"StS2 application support directory not found at expected path; run-file watcher disabled.");
-            return Array.Empty<string>();
+            return Array.Empty<HistoryDir>();
         }
 
         var steamDir = Path.Combine(root, "steam");
         if (!Directory.Exists(steamDir))
         {
             log.Warn($"No 'steam' subdirectory under '{root}'; run-file watcher disabled.");
-            return Array.Empty<string>();
+            return Array.Empty<HistoryDir>();
         }
 
-        var dirs = new List<string>();
+        var dirs = new List<HistoryDir>();
         foreach (var steamUser in Directory.GetDirectories(steamDir))
         {
+            var steamId = Path.GetFileName(steamUser);
             foreach (var profile in Directory.GetDirectories(steamUser, "profile*"))
             {
                 var history = Path.Combine(profile, "saves", "history");
-                if (Directory.Exists(history)) dirs.Add(history);
+                if (Directory.Exists(history)) dirs.Add(new HistoryDir(history, steamId));
             }
         }
 
         if (dirs.Count == 0)
         {
             log.Warn($"No profile under '{steamDir}' has a 'saves/history' directory; run-file watcher disabled.");
-            return Array.Empty<string>();
+            return Array.Empty<HistoryDir>();
         }
 
         // Sort by file count descending so logs show "biggest" profile first; the
         // watcher monitors all of them regardless.
         dirs.Sort((a, b) =>
-            Directory.GetFiles(b, "*.run").Length.CompareTo(Directory.GetFiles(a, "*.run").Length));
+            Directory.GetFiles(b.Path, "*.run").Length.CompareTo(Directory.GetFiles(a.Path, "*.run").Length));
         return dirs;
     }
 

--- a/mod/StudyTheSpire/StudyTheSpire.cs
+++ b/mod/StudyTheSpire/StudyTheSpire.cs
@@ -92,9 +92,10 @@ public partial class StudyTheSpire : Node
         log.Info($"Starting run-file watcher across {historyDirs.Count} profile(s).");
         foreach (var historyDir in historyDirs)
         {
+            var steamId = historyDir.SteamId;
             var w = new RunFileWatcher(
-                historyDir: historyDir,
-                onFileReady: file => uploader.UploadAsync(file),
+                historyDir: historyDir.Path,
+                onFileReady: file => uploader.UploadAsync(file, steamId),
                 log: log);
             w.Start();
             w.EnumerateExisting();

--- a/web/src/app/dashboard/runs/[runId]/page.tsx
+++ b/web/src/app/dashboard/runs/[runId]/page.tsx
@@ -47,7 +47,6 @@ export default async function RunDetailPage({
   }
 
   const { run, rawJson, fileName } = (await res.json()) as RunDetailRep;
-  const prettyJson = prettyPrint(rawJson);
 
   return (
     <div className="space-y-6">
@@ -90,7 +89,7 @@ export default async function RunDetailPage({
           Raw run-file JSON
         </summary>
         <pre className="bg-muted/30 max-h-[60vh] overflow-auto px-3 py-2 text-xs leading-relaxed">
-          <code>{prettyJson}</code>
+          <code>{rawJson}</code>
         </pre>
       </details>
     </div>
@@ -147,10 +146,3 @@ function formatAbsolute(iso: string): string {
   return d.toLocaleString();
 }
 
-function prettyPrint(json: string): string {
-  try {
-    return JSON.stringify(JSON.parse(json), null, 2);
-  } catch {
-    return json;
-  }
-}


### PR DESCRIPTION
In co-op runs the game writes every lobby player into `players[]`, so `RunStore.parseRunFile` blindly picking `players[0]` attributed the host's character to everyone. Mod now sends the uploader's Steam ID (parsed from the `steam/<id>/profile<n>/saves/history/` path) as `X-Local-Player-Id`; the backend matches on `players[].id` and falls back to index 0 only when the header is absent.

Bypass Kairo's `body: String` deserialization with `call.receiveText()` on `POST /imports/run-file` so the raw JSON survives byte-for-byte — Jackson's String coercion would round-trip 17-digit SteamID64s through a representation that loses precision.

Drop `JSON.parse`/`JSON.stringify` from the dashboard's raw-JSON viewer for the same reason: JS `Number` is IEEE 754, lossy on these IDs. The game already pretty-prints the file, so render it as-is.

Closes #1.